### PR TITLE
Fixing deprecation warnings in Atom

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -1,11 +1,11 @@
 @import "syntax-variables";
 
-.editor, .editor-colors, :host {
+atom-text-editor, atom-text-editor-colors, :host {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 }
 
-.editor, :host {
+atom-text-editor, :host {
   .wrap-guide {
     background-color: @syntax-wrap-guide-color;
   }
@@ -334,7 +334,7 @@
 }
 
 
-.editor.mini .scroll-view,
+atom-text-editor[mini] .scroll-view,
 :host(.mini) .scroll-view {
   padding-left: 1px;
 }


### PR DESCRIPTION
Just find-replaced the .editor selectors and the .mini one. Result looks fine to me.

See issue: https://github.com/Kikobeats/afterglow-monokai-syntax/issues/1
